### PR TITLE
feat(auth): add Auth0Client and Next.js middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^3.8.0",
+    "@auth0/nextjs-auth0": "^4.4.2",
     "next": "15.4.6",
     "openapi-types": "^12.1.3",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@auth0/nextjs-auth0':
-        specifier: ^3.8.0
-        version: 3.8.0(next@15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        specifier: ^4.4.2
+        version: 4.9.0(next@15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next:
         specifier: 15.4.6
         version: 15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -64,11 +64,16 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@auth0/nextjs-auth0@3.8.0':
-    resolution: {integrity: sha512-xMzpkCuJAZ7tquJOZr7W4Jm9155EDotAACtdd9R9t4ATZgNGUzDQfPMogYJ2O14WB86sZSrp3rpJo4cspQYcSA==}
-    engines: {node: '>=16'}
+  '@auth0/nextjs-auth0@4.9.0':
+    resolution: {integrity: sha512-z53aI+5h7CYRDYXe/iiPzEFg32PWRiKzdSemjyHLnmeQQgiZ3Va7ZYrUWggNCgtzm314sHsipzyyafiNgSNUrQ==}
     peerDependencies:
-      next: ^10.0.0 || ^11.0.0 || ^12.3.5 || ^13.5.9 || ^14.2.25 || ^15.2.3
+      next: ^14.2.25 || ^15.2.3
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+
+  '@edge-runtime/cookies@5.0.2':
+    resolution: {integrity: sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==}
+    engines: {node: '>=16'}
 
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
@@ -116,12 +121,6 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@hapi/hoek@9.3.0':
-    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
-
-  '@hapi/topo@5.1.0':
-    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -369,15 +368,6 @@ packages:
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
-
-  '@sideway/address@4.1.5':
-    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
-
-  '@sideway/formula@3.0.1':
-    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
-
-  '@sideway/pinpoint@2.0.0':
-    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -782,10 +772,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -835,6 +821,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -1277,11 +1267,8 @@ packages:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
-  joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
-
-  jose@4.15.9:
-    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+  jose@6.0.12:
+    resolution: {integrity: sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1396,10 +1383,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -1475,16 +1458,12 @@ packages:
       sass:
         optional: true
 
-  oauth4webapi@2.17.0:
-    resolution: {integrity: sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==}
+  oauth4webapi@3.7.0:
+    resolution: {integrity: sha512-Q52wTPUWPsVLVVmTViXPQFMW2h2xv2jnDGxypjpelCFKaOjLsm7AxYuOk1oQgFm95VNDbuggasu9htXrz6XwKw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1514,15 +1493,8 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  oidc-token-hash@5.1.1:
-    resolution: {integrity: sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==}
-    engines: {node: ^10.13.0 || >=12.0.0}
-
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
-
-  openid-client@5.7.1:
-    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1768,6 +1740,11 @@ packages:
   swagger-ui-dist@5.27.1:
     resolution: {integrity: sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==}
 
+  swr@2.3.6:
+    resolution: {integrity: sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwindcss@4.1.12:
     resolution: {integrity: sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==}
 
@@ -1837,8 +1814,10 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url-join@4.0.1:
-    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -1865,9 +1844,6 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -1880,20 +1856,18 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@auth0/nextjs-auth0@3.8.0(next@15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@auth0/nextjs-auth0@4.9.0(next@15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
+      '@edge-runtime/cookies': 5.0.2
       '@panva/hkdf': 1.2.1
-      cookie: 0.7.2
-      debug: 4.4.1
-      joi: 17.13.3
-      jose: 4.15.9
+      jose: 6.0.12
       next: 15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      oauth4webapi: 2.17.0
-      openid-client: 5.7.1
-      tslib: 2.8.1
-      url-join: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
+      oauth4webapi: 3.7.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      swr: 2.3.6(react@19.1.0)
+
+  '@edge-runtime/cookies@5.0.2': {}
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -1954,12 +1928,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
-
-  '@hapi/hoek@9.3.0': {}
-
-  '@hapi/topo@5.1.0':
-    dependencies:
-      '@hapi/hoek': 9.3.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -2141,14 +2109,6 @@ snapshots:
   '@rushstack/eslint-patch@1.12.0': {}
 
   '@scarf/scarf@1.4.0': {}
-
-  '@sideway/address@4.1.5':
-    dependencies:
-      '@hapi/hoek': 9.3.0
-
-  '@sideway/formula@3.0.1': {}
-
-  '@sideway/pinpoint@2.0.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2566,8 +2526,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  cookie@0.7.2: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2617,6 +2575,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  dequal@2.0.3: {}
 
   detect-libc@2.0.4: {}
 
@@ -3221,15 +3181,7 @@ snapshots:
 
   jiti@2.5.1: {}
 
-  joi@17.13.3:
-    dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.5
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
-
-  jose@4.15.9: {}
+  jose@6.0.12: {}
 
   js-tokens@4.0.0: {}
 
@@ -3324,10 +3276,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
-
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3390,11 +3338,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  oauth4webapi@2.17.0: {}
+  oauth4webapi@3.7.0: {}
 
   object-assign@4.1.1: {}
-
-  object-hash@2.2.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -3436,16 +3382,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  oidc-token-hash@5.1.1: {}
-
   openapi-types@12.1.3: {}
-
-  openid-client@5.7.1:
-    dependencies:
-      jose: 4.15.9
-      lru-cache: 6.0.0
-      object-hash: 2.2.0
-      oidc-token-hash: 5.1.1
 
   optionator@0.9.4:
     dependencies:
@@ -3757,6 +3694,12 @@ snapshots:
     dependencies:
       '@scarf/scarf': 1.4.0
 
+  swr@2.3.6(react@19.1.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+
   tailwindcss@4.1.12: {}
 
   tapable@2.2.2: {}
@@ -3868,7 +3811,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-join@4.0.1: {}
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -3916,8 +3861,6 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
-
-  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 

--- a/src/app/api/auth/[...auth0]/route.ts
+++ b/src/app/api/auth/[...auth0]/route.ts
@@ -1,93 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-// シンプルなAuth0認証処理
+// 互換のため、/api/auth/* へのアクセスを /auth/* に転送
 export async function GET(
   request: NextRequest,
   { params }: { params: { auth0: string[] } }
 ) {
   const route = params.auth0[0];
-  const { searchParams } = new URL(request.url);
-  
-  // 共通の環境変数を取得
-  const auth0Domain = process.env.AUTH0_ISSUER_BASE_URL;
-  const clientId = process.env.AUTH0_CLIENT_ID;
-  const baseUrl = process.env.AUTH0_BASE_URL;
-  
-  switch (route) {
-    case 'login':
-      // Auth0のログインページにリダイレクト
-      
-      // デバッグ情報をログ出力
-      console.log('環境変数チェック:', {
-        auth0Domain,
-        clientId,
-        baseUrl
-      });
-      
-      // 環境変数が設定されていない場合のエラーハンドリング
-      if (!auth0Domain || !clientId || !baseUrl) {
-        return NextResponse.json({
-          error: '環境変数が設定されていません',
-          details: {
-            AUTH0_ISSUER_BASE_URL: !!auth0Domain,
-            AUTH0_CLIENT_ID: !!clientId,
-            AUTH0_BASE_URL: !!baseUrl
-          }
-        }, { status: 500 });
-      }
-      
-      const redirectUri = `${baseUrl}/api/auth/callback`;
-      const authUrl = `${auth0Domain}/authorize?` +
-        `response_type=code&` +
-        `client_id=${clientId}&` +
-        `redirect_uri=${encodeURIComponent(redirectUri)}&` +
-        `scope=openid profile email`;
-      
-      console.log('Auth0 URL:', authUrl);
-      return NextResponse.redirect(authUrl);
-      
-    case 'callback':
-      // Auth0からのコールバック処理
-      const code = searchParams.get('code');
-      if (code) {
-        // 簡単な成功ページにリダイレクト
-        return NextResponse.redirect(new URL('/?success=true', request.url));
-      }
-      return NextResponse.redirect(new URL('/?error=callback_failed', request.url));
-      
-    case 'logout':
-      // ログアウト処理
-      console.log('ログアウト処理開始:', {
-        auth0Domain,
-        baseUrl
-      });
-      
-      if (!auth0Domain || !baseUrl) {
-        return NextResponse.json({
-          error: 'ログアウト用環境変数が不足',
-          details: {
-            AUTH0_ISSUER_BASE_URL: !!auth0Domain,
-            AUTH0_BASE_URL: !!baseUrl
-          }
-        }, { status: 500 });
-      }
-      
-      const logoutUrl = `${auth0Domain}/logout?` +
-        `returnTo=${encodeURIComponent(baseUrl)}`;
-        
-      console.log('構築されたログアウトURL:', logoutUrl);
-      return NextResponse.redirect(logoutUrl);
-      
-    case 'me':
-      // ユーザー情報返却（テスト用）
-      return NextResponse.json({
-        user: null,
-        message: 'カスタム実装：ログインが必要です'
-      });
-      
-    default:
-      return NextResponse.json({ error: 'Unknown auth route' }, { status: 404 });
-  }
+  const url = new URL(request.url);
+  url.pathname = `/auth/${route}`;
+  return NextResponse.redirect(url);
 }
 
 export const POST = GET;

--- a/src/app/api/protected/route.ts
+++ b/src/app/api/protected/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getSession } from '@auth0/nextjs-auth0';
+import { auth0 } from '@/lib/auth0';
 
 export async function GET(request: NextRequest) {
   try {
-    const session = await getSession(request, NextResponse.next());
+    const session = await auth0.getSession(request);
     
     if (!session) {
       return NextResponse.json(

--- a/src/app/auth/[...auth0]/route.ts
+++ b/src/app/auth/[...auth0]/route.ts
@@ -1,6 +1,0 @@
-import { handleAuth } from '@auth0/nextjs-auth0'
-
-export const GET = handleAuth()
-export const POST = GET
-
-

--- a/src/app/auth/[...auth0]/route.ts
+++ b/src/app/auth/[...auth0]/route.ts
@@ -1,0 +1,6 @@
+import { handleAuth } from '@auth0/nextjs-auth0'
+
+export const GET = handleAuth()
+export const POST = GET
+
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-// import { Auth0Provider } from '@auth0/nextjs-auth0';
+import { Auth0Provider } from '@auth0/nextjs-auth0';
+import { auth0 } from '@/lib/auth0';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -18,18 +19,18 @@ export const metadata: Metadata = {
   description: "Auth0とNext.jsを使用した認証システムのデモ",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const session = await auth0.getSession();
   return (
     <html lang="ja">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {/* 一時的にAuth0Providerを無効化 */}
-        {children}
+        <Auth0Provider user={session?.user}>{children}</Auth0Provider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,75 +1,33 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import Header from '@/components/Header';
+import { useUser } from '@auth0/nextjs-auth0';
 
 export default function Home() {
-  const searchParams = useSearchParams();
-  const [authStatus, setAuthStatus] = useState<'unknown' | 'success' | 'error' | 'logged_out'>('unknown');
-  const [user, setUser] = useState<any>(null);
-
-  useEffect(() => {
-    // URLパラメータから認証状態を確認
-    if (searchParams.get('success') === 'true') {
-      setAuthStatus('success');
-      // ユーザー情報を取得（カスタム実装）
-      setUser({
-        name: 'テストユーザー',
-        email: 'test@example.com',
-        sub: 'auth0|test123',
-        picture: 'https://via.placeholder.com/100'
-      });
-    } else if (searchParams.get('error')) {
-      setAuthStatus('error');
-    } else if (searchParams.get('logout') === 'true') {
-      setAuthStatus('logged_out');
-      setUser(null);
-    }
-  }, [searchParams]);
-
-  const isLoading = false;
-  const error = authStatus === 'error' ? { message: 'ログインに失敗しました' } : null;
-
-  if (isLoading) return <div>読み込み中...</div>;
-  if (error) return <div>エラー: {error.message}</div>;
+  const { user, error, isLoading } = useUser();
 
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
-      
       <main className="container mx-auto px-4 py-8">
         <div className="text-center">
-          <h2 className="text-3xl font-bold text-gray-900 mb-6">
-            Auth0 認証システムのデモ
-          </h2>
+          <h2 className="text-3xl font-bold text-gray-900 mb-6">Auth0 認証システムのデモ</h2>
 
-          {/* 認証状態の表示 */}
-          <div className="mb-6 p-4 rounded-lg border">
-            <h3 className="text-lg font-semibold mb-2">認証状態確認</h3>
+          <div className="mb-6 p-4 rounded-lg border border-gray-200 bg-white text-gray-900">
+            <h3 className="text-lg font-semibold mb-2 text-gray-900">認証状態確認</h3>
             <div className="text-sm space-y-1">
-              <p><strong>認証状態:</strong> 
-                <span className={`ml-2 px-2 py-1 rounded ${
-                  authStatus === 'success' ? 'bg-green-100 text-green-800' :
-                  authStatus === 'error' ? 'bg-red-100 text-red-800' :
-                  authStatus === 'logged_out' ? 'bg-blue-100 text-blue-800' :
-                  'bg-gray-100 text-gray-800'
-                }`}>
-                  {authStatus === 'success' ? '認証済み' :
-                   authStatus === 'error' ? 'エラー' :
-                   authStatus === 'logged_out' ? 'ログアウト済み' :
-                   '未認証'}
+              <p>
+                <strong>認証状態:</strong>
+                <span className={`ml-2 px-2 py-1 rounded ${user ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
+                  {isLoading ? '読み込み中…' : user ? '認証済み' : '未認証'}
                 </span>
               </p>
-              <p><strong>URL パラメータ:</strong> {typeof window !== 'undefined' ? window.location.search || '(なし)' : '読み込み中...'}</p>
             </div>
           </div>
-          
+
           {user ? (
-            <div className="bg-white rounded-lg shadow-md p-6 max-w-md mx-auto">
-              <h3 className="text-xl font-semibold text-green-600 mb-4">
-                ログイン成功！
-              </h3>
+            <div className="bg-white rounded-lg shadow-md p-6 max-w-md mx-auto text-gray-900">
+              <h3 className="text-xl font-semibold text-green-600 mb-4">ログイン中</h3>
               <div className="text-left space-y-2">
                 <p><strong>ユーザーID:</strong> {user.sub}</p>
                 <p><strong>名前:</strong> {user.name}</p>
@@ -78,47 +36,24 @@ export default function Home() {
               </div>
             </div>
           ) : (
-            <div className="bg-white rounded-lg shadow-md p-6 max-w-md mx-auto">
-              <h3 className="text-xl font-semibold text-blue-600 mb-4">
-                認証が必要です
-              </h3>
-              <p className="text-gray-600 mb-4">
-                このアプリケーションの機能を利用するには、ログインしてください。
-              </p>
-              <a
-                href="/api/auth/login"
-                className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-              >
-                ログイン
-              </a>
+            <div className="bg-white rounded-lg shadow-md p-6 max-w-md mx-auto text-gray-900">
+              <h3 className="text-xl font-semibold text-blue-600 mb-4">認証が必要です</h3>
+              <p className="text-gray-600 mb-4">このアプリケーションの機能を利用するには、ログインしてください。</p>
+              <a href="/auth/login" className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">ログイン</a>
             </div>
           )}
         </div>
 
         <div className="mt-12">
-          <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-            認証システムの機能
-          </h3>
-          
+          <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">認証システムの機能</h3>
           <div className="grid md:grid-cols-2 gap-6">
             <div className="bg-white rounded-lg shadow-md p-6">
-              <h4 className="text-lg font-semibold text-blue-600 mb-3">
-                ログイン・ログアウト
-              </h4>
-              <p className="text-gray-600">
-                Auth0を使用したソーシャルログインと認証状態の管理。
-                Google、GitHub、メールアドレスなどでログイン可能。
-              </p>
+              <h4 className="text-lg font-semibold text-blue-600 mb-3">ログイン・ログアウト</h4>
+              <p className="text-gray-600">Auth0を使用したソーシャルログインと認証状態の管理。</p>
             </div>
-            
             <div className="bg-white rounded-lg shadow-md p-6">
-              <h4 className="text-lg font-semibold text-green-600 mb-3">
-                保護されたAPI
-              </h4>
-              <p className="text-gray-600">
-                認証されたユーザーのみアクセス可能なAPIエンドポイント。
-                SwaggerUIでAPIの仕様とテストが可能。
-              </p>
+              <h4 className="text-lg font-semibold text-green-600 mb-3">保護されたAPI</h4>
+              <p className="text-gray-600">認証されたユーザーのみアクセス可能なAPIエンドポイント。</p>
             </div>
           </div>
         </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser, withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { useUser } from '@auth0/nextjs-auth0';
 import Header from '@/components/Header';
 
 function Profile() {
@@ -106,4 +106,4 @@ function Profile() {
   );
 }
 
-export default withPageAuthRequired(Profile);
+export default Profile;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -93,7 +93,7 @@ function Profile() {
                   <label className="block text-sm font-medium text-gray-700 mb-2">
                     完全なユーザー情報（開発用）
                   </label>
-                  <pre className="bg-gray-100 p-4 rounded text-xs overflow-auto">
+                  <pre className="bg-gray-100 p-4 rounded text-xs overflow-auto text-gray-900">
                     {JSON.stringify(user, null, 2)}
                   </pre>
                 </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,27 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useUser } from '@auth0/nextjs-auth0/client';
 
 export default function Header() {
-  const searchParams = useSearchParams();
-  const [user, setUser] = useState<any>(null);
-
-  useEffect(() => {
-    // URLパラメータから認証状態を確認
-    if (searchParams.get('success') === 'true') {
-      setUser({
-        name: 'テストユーザー',
-        email: 'test@example.com'
-      });
-    } else if (searchParams.get('logout') === 'true') {
-      setUser(null);
-    }
-  }, [searchParams]);
-
-  const isLoading = false;
-  const error = null;
+  const { user, isLoading, error } = useUser();
 
   if (isLoading) return <div>読み込み中...</div>;
   if (error) return <div>エラー: {error.message}</div>;
@@ -50,7 +33,7 @@ export default function Header() {
                 API ドキュメント
               </Link>
               <a
-                href="/api/auth/logout"
+                href="/auth/logout"
                 className="bg-red-500 hover:bg-red-700 px-3 py-1 rounded"
               >
                 ログアウト
@@ -58,7 +41,7 @@ export default function Header() {
             </>
           ) : (
             <a
-              href="/api/auth/login"
+              href="/auth/login"
               className="bg-green-500 hover:bg-green-700 px-3 py-1 rounded"
             >
               ログイン

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useUser } from '@auth0/nextjs-auth0/client';
+import { useUser } from '@auth0/nextjs-auth0';
 
 export default function Header() {
   const { user, isLoading, error } = useUser();

--- a/src/lib/auth0.ts
+++ b/src/lib/auth0.ts
@@ -1,0 +1,15 @@
+import { Auth0Client } from '@auth0/nextjs-auth0/server'
+
+export const auth0 = new Auth0Client({
+	authorizationParameters: {
+		audience: process.env.AUTH0_AUDIENCE ?? '',
+		scope: 'openid profile email'
+	},
+	session: {
+		rolling: true,
+		absoluteDuration: 60 * 60 * 24 * 3,
+		inactivityDuration: 60 * 60 * 24 * 1
+	}
+})
+
+

--- a/src/lib/auth0.ts
+++ b/src/lib/auth0.ts
@@ -1,9 +1,16 @@
 import { Auth0Client } from '@auth0/nextjs-auth0/server'
 
+const issuer = process.env.AUTH0_ISSUER_BASE_URL
+const derivedDomain = issuer?.replace(/^https?:\/\//, '').replace(/\/?$/, '')
+const devFallbackSecret =
+  process.env.NODE_ENV === 'development'
+    ? 'dev-secret-change-me-12345678901234567890123456789012'
+    : undefined
+
 export const auth0 = new Auth0Client({
-	domain: process.env.AUTH0_DOMAIN,
+	domain: process.env.AUTH0_DOMAIN || derivedDomain,
 	appBaseUrl: process.env.APP_BASE_URL || process.env.AUTH0_BASE_URL,
-	secret: process.env.AUTH0_SECRET,
+	secret: process.env.AUTH0_SECRET || devFallbackSecret,
 	clientId: process.env.AUTH0_CLIENT_ID,
 	clientSecret: process.env.AUTH0_CLIENT_SECRET,
 	authorizationParameters: {

--- a/src/lib/auth0.ts
+++ b/src/lib/auth0.ts
@@ -1,6 +1,11 @@
 import { Auth0Client } from '@auth0/nextjs-auth0/server'
 
 export const auth0 = new Auth0Client({
+	domain: process.env.AUTH0_DOMAIN,
+	appBaseUrl: process.env.APP_BASE_URL || process.env.AUTH0_BASE_URL,
+	secret: process.env.AUTH0_SECRET,
+	clientId: process.env.AUTH0_CLIENT_ID,
+	clientSecret: process.env.AUTH0_CLIENT_SECRET,
 	authorizationParameters: {
 		audience: process.env.AUTH0_AUDIENCE ?? '',
 		scope: 'openid profile email'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,6 +11,15 @@ const isPublicPage = (pathname: string) => {
 }
 
 export async function middleware(request: NextRequest) {
+	// 環境変数の有無をブール値でログ（値自体は出力しない）
+	console.log('Auth0 env present', {
+		domain: !!(process.env.AUTH0_DOMAIN || process.env.AUTH0_ISSUER_BASE_URL),
+		appBaseUrl: !!(process.env.APP_BASE_URL || process.env.AUTH0_BASE_URL),
+		secret: !!process.env.AUTH0_SECRET,
+		clientId: !!process.env.AUTH0_CLIENT_ID,
+		clientSecret: !!process.env.AUTH0_CLIENT_SECRET,
+	})
+
 	const authRes = await auth0.middleware(request)
 
 	const { pathname } = request.nextUrl

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { auth0 } from './lib/auth0'
+
+const isPublicPage = (pathname: string) => {
+	return (
+		/^\/(api\/swagger|api-docs)(\/.*)?$/.test(pathname) ||
+		/^\/$/.test(pathname) ||
+		/\.(jpg|jpeg|png|gif|ico|svg)$/.test(pathname)
+	)
+}
+
+export async function middleware(request: NextRequest) {
+	const authRes = await auth0.middleware(request)
+
+	const { pathname } = request.nextUrl
+	if (isPublicPage(pathname)) {
+		return NextResponse.next()
+	}
+
+	if (request.nextUrl.pathname.startsWith('/auth')) {
+		return authRes
+	}
+
+	const session = await auth0.getSession(request)
+	if (!session) {
+		return NextResponse.redirect(new URL('/auth/login', request.nextUrl.origin))
+	}
+
+	try {
+		await auth0.getAccessToken(request, authRes)
+	} catch {
+		return NextResponse.redirect(new URL('/auth/login', request.nextUrl.origin))
+	}
+
+	return authRes
+}
+
+export const config = {
+	matcher: [
+		'/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'
+	]
+}
+
+


### PR DESCRIPTION
## 変更点
- 依存更新
  - @auth0/nextjs-auth0 を v4 系へ更新（package.json）
- 追加
  - `src/lib/auth0.ts`: Auth0Client のインスタンス化（audience/scope/セッション設定）
  - `src/middleware.ts`: 未認証の一括保護・トークン更新の永続化・公開ページの許可
  - src/app/auth/[...auth0]/route.ts: GET/POST を SDK ハンドラへ委譲
- 互換維持
  - `src/app/api/auth/[...auth0]/route.ts`: 既存の /api/auth/* へのアクセスを /auth/* にリダイレクト
- 既存コードの調整
  - `src/app/layout.tsx`: サーバー側で auth0.getSession() を取得し、<Auth0Provider user={session?.user}> で配布
  - `src/components/Header.tsx`: useUser ベースに置換、リンクを /auth/login /auth/logout に統一
  - `src/app/api/protected/route.ts`: auth0.getSession(request) を使用
  - `src/app/profile/page.tsx:` withPageAuthRequired を外し、Middleware 保護前提に

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - App-wide Auth0 integration with provider and centralized session management.
  - Middleware enforces authentication for protected routes, redirecting unauthenticated users to login.
  - Header and home UI now reflect real auth state and provide Login/Logout/Profile flows.
  - API auth requests are forwarded to unified /auth endpoints with query parameters preserved.

- Changes
  - Profile page switched from server-gated to client-driven display based on session.

- Chores
  - Upgraded Auth0 SDK to v4.4.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->